### PR TITLE
address->location_type 저장 로직

### DIFF
--- a/backend/src/main/java/com/chakak/controller/AdminDashboardController.java
+++ b/backend/src/main/java/com/chakak/controller/AdminDashboardController.java
@@ -24,7 +24,8 @@ public class AdminDashboardController {
     	System.out.println("대시보드 접근 성공");
         model.addAttribute("topVehicles", statisticsService.getTopVehicleReports()); // 차량 통계
         model.addAttribute("typeStats", statisticsService.getViolationTypeStats()); // 유형별 통계
-        model.addAttribute("addressStats", statisticsService.getFrequentAddresses()); // 반복 지역 통계 
+        model.addAttribute("locationStats", statisticsService.getFrequentAddresses()); // 반복 지역 통계 
+       
         return "admin/dashboard";
     }
 }

--- a/backend/src/main/java/com/chakak/domain/Report.java
+++ b/backend/src/main/java/com/chakak/domain/Report.java
@@ -70,6 +70,7 @@ public class Report {
 	private String address; //지도상 주소
 	private double latitude; // 위도
 	private double longitude; // 경도
+	private String locationType; // 지역(시/구/동 단위)
 	private String description;
 	
     @Column(name = "view_cnt")

--- a/backend/src/main/java/com/chakak/dto/response/FrequentAddressDto.java
+++ b/backend/src/main/java/com/chakak/dto/response/FrequentAddressDto.java
@@ -1,7 +1,7 @@
 package com.chakak.dto.response;
 
-// 반복 제보 위치 통계 (지역별)
+// 반복 제보 위치 통계 (지역별) 인터페이스 기반 Rojection
 public interface FrequentAddressDto {
-    String getAddress();
+    String getLocation();
     Long getCount();
 }

--- a/backend/src/main/java/com/chakak/repository/ReportRepository.java
+++ b/backend/src/main/java/com/chakak/repository/ReportRepository.java
@@ -44,10 +44,10 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     
     // 반복 제보 위치 통계 (지역별)
     @Query(value = """
-    	    SELECT address, COUNT(*) AS count
+    	    SELECT location_type AS location, COUNT(*) AS count
     	    FROM report
-    	    WHERE address IS NOT NULL
-    	    GROUP BY address
+    	    WHERE location_type IS NOT NULL
+    	    GROUP BY location_type
     	    ORDER BY count DESC
     	    LIMIT 10
     	""", nativeQuery = true)

--- a/backend/src/main/java/com/chakak/service/ReportServiceImpl.java
+++ b/backend/src/main/java/com/chakak/service/ReportServiceImpl.java
@@ -8,6 +8,7 @@ import com.chakak.domain.Report;
 import com.chakak.domain.User;
 import com.chakak.repository.ReportRepository;
 import com.chakak.repository.UserRepository;
+import com.chakak.util.AddressUtils;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j; //로그 디버그용
@@ -28,6 +29,11 @@ public class ReportServiceImpl implements ReportService{
 	            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자"));
 
 	    report.setUser(user); // 영속 상태로 다시 교체
+	    
+	    // address를 지역(location_type)으로 파싱 
+	    String address = report.getAddress();
+	    String locationType = AddressUtils.extractRegion(address);
+	    report.setLocationType(locationType);
 		return repository.save(report);
 	}
 

--- a/backend/src/main/java/com/chakak/util/AddressUtils.java
+++ b/backend/src/main/java/com/chakak/util/AddressUtils.java
@@ -1,0 +1,20 @@
+package com.chakak.util;
+
+
+/**
+ * 주소에서 시/구/동 단위 추출
+ * ex: "인천 남동구 간석동 414-4" → "인천 남동구 간석동"
+ */
+public class AddressUtils {
+	public static String extractRegion(String address) {
+        if (address == null || address.isBlank()) return null;
+        String[] parts = address.trim().split(" ");
+        if (parts.length >= 3) {
+            return parts[0] + " " + parts[1] + " " + parts[2];
+        } else if (parts.length >= 2) {
+            return parts[0] + " " + parts[1];
+        } else {
+            return address;
+        }
+    }
+}

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -49,9 +49,9 @@
             <th>주소</th>
             <th>제보 수</th>
         </tr>
-        <tr th:each="a, stat : ${addressStats}">
+        <tr th:each="a, stat : ${locationStats}">
             <td th:text="${stat.index + 1}">1</td>
-            <td th:text="${a.address}">서울시 강남구</td>
+            <td th:text="${a.location}">서울시 강남구</td>
             <td th:text="${a.count}">7</td>
         </tr>
     </table>


### PR DESCRIPTION
지역별 제보 순위 통계를
 address기준이 아닌, locaton_type 컬럼을 추가하여
시/구/동 지역명만 따로 추출하여 location_type컬럼에 저장하고 그것을 기준으로 순위 매기는 것으로 바꾸었습니다.
